### PR TITLE
Introduce MLIRSwiftSupport

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: LLVM
+AlwaysBreakTemplateDeclarations: Yes

--- a/Sources/CMLIR/CMLIR.h
+++ b/Sources/CMLIR/CMLIR.h
@@ -5,3 +5,5 @@
 #include <mlir-c/BuiltinTypes.h>
 #include <mlir-c/Registration.h>
 #include <mlir-c/Transforms.h>
+
+#include <MLIRSwiftSupport/MLIRSwiftSupport.h>

--- a/Sources/CMLIR/module.modulemap
+++ b/Sources/CMLIR/module.modulemap
@@ -37,6 +37,7 @@ module CMLIR [system] {
   link "MLIRSideEffectInterfaces"
   link "MLIRStandard"
   link "MLIRSupport"
+  link "MLIRSwiftSupport"
   link "MLIRTensor"
   link "MLIRTransformUtils"
   link "MLIRTransforms"

--- a/Tools/MLIRSwiftSupport/CMakeLists.txt
+++ b/Tools/MLIRSwiftSupport/CMakeLists.txt
@@ -1,0 +1,27 @@
+# This project is meant to compile as part of the LLVM build using LLVM_EXTERNAL_PROJECTS
+# See `build-dependencies` for more details
+
+cmake_minimum_required(VERSION 3.13.4)
+
+include_directories(${MLIR_INCLUDE_DIRS})
+include_directories(${LLVM_INCLUDE_DIRS})
+
+# Sources
+file(GLOB sources *.cpp)
+add_llvm_library(MLIRSwiftSupport
+    ${sources}
+    LINK_LIBS PUBLIC
+    MLIRCAPI)
+    
+# Headers
+add_custom_target(MLIRSwiftSupport-headers)
+install(
+    FILES
+    # Headers listed here will be installed
+    MLIRSwiftSupport.h
+
+    DESTINATION include/MLIRSwiftSupport
+    COMPONENT MLIRSwiftSupport-headers)
+add_llvm_install_targets(install-MLIRSwiftSupport-headers
+    DEPENDS MLIRSwiftSupport-headers
+    COMPONENT MLIRSwiftSupport-headers)

--- a/Tools/MLIRSwiftSupport/MLIRSwiftSupport.cpp
+++ b/Tools/MLIRSwiftSupport/MLIRSwiftSupport.cpp
@@ -1,0 +1,2 @@
+
+#include "MLIRSwiftSupport.h"

--- a/Tools/MLIRSwiftSupport/MLIRSwiftSupport.h
+++ b/Tools/MLIRSwiftSupport/MLIRSwiftSupport.h
@@ -1,0 +1,12 @@
+#ifndef MLIRSwiftSupport_h
+#define MLIRSwiftSupport_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MLIRSwiftSupport_h */

--- a/Tools/build-dependencies
+++ b/Tools/build-dependencies
@@ -33,10 +33,6 @@ LLVM_SYSTEM_LIBRARY_TARGETS="
   $PROJECT_ROOT/Sources/CDialects
   $PROJECT_ROOT/Sources/CMLIR
   $LLVM_ADDITIONAL_SYSTEM_LIBRARY_TARGETS"
-LLVM_HEADER_TARGETS="
-  install-llvm-headers
-  install-mlir-headers
-  $LLVM_ADDITIONAL_HEADER_TARGETS"
 TOOLS_INSTALL_PATH="$DEPENDENCIES_ROOT/installed/tools"
 PKG_CONFIG_PATH=${PKG_CONFIG_PATH:-/usr/local/lib/pkgconfig}
 PKG_CONFIG_FILE_PATH="$PKG_CONFIG_PATH/LLVM-for-Swift.pc"
@@ -54,13 +50,30 @@ Libs: -lcurses $(
 EOF
 )
 
+# Create a comma-separated list of external projects
+LLVM_EXTERNAL_PROJECTS=$(
+  delim=""
+  for TARGET in $(echo "
+      MLIRSwiftSupport
+      $LLVM_ADDITIONAL_EXTERNAL_PROJECTS")
+  do
+    printf "%s" "$delim$TARGET"
+    delim=","
+  done
+)
+
+# Create a list of install targets with some extra ceremony so they up as a bash array
 LLVM_INSTALL_TARGETS=()
 for TARGET in $(echo "$(
   for SYSTEM_LIBRARY_TARGET in $LLVM_SYSTEM_LIBRARY_TARGETS; do
     sed -n 's/link "\(.*\)"/install-\1/p' < "$SYSTEM_LIBRARY_TARGET/module.modulemap"
   done;
-  echo "$LLVM_HEADER_TARGETS"
-  )" | xargs | tr ' ' '\n' | sort | uniq)
+  echo "
+    install-MLIRSwiftSupport-headers
+    install-llvm-headers
+    install-mlir-headers
+    $LLVM_ADDITIONAL_TARGETS"
+  )" | xargs | tr ' ' '\n' | sort -u)
 do
   LLVM_INSTALL_TARGETS+=("$TARGET")
 done
@@ -124,6 +137,9 @@ CMAKE_OSX_DEPLOYMENT_TARGET=""
   -G Ninja \
   -DCMAKE_INSTALL_PREFIX="$INSTALL_PATH" \
   ${CMAKE_OSX_DEPLOYMENT_TARGET:+ "-DCMAKE_OSX_DEPLOYMENT_TARGET=$CMAKE_OSX_DEPLOYMENT_TARGET"} \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}" \
   -DLLVM_BUILD_EXAMPLES=OFF \
   -DLLVM_INSTALL_UTILS=OFF \
   -DLLVM_BUILD_TOOLS=OFF \
@@ -132,9 +148,8 @@ CMAKE_OSX_DEPLOYMENT_TARGET=""
   -DLLVM_ENABLE_OCAMLDOC=OFF \
   -DLLVM_ENABLE_BINDINGS=OFF \
   -DLLVM_ENABLE_ASSERTIONS=ON \
-  -DCMAKE_C_COMPILER=clang \
-  -DCMAKE_CXX_COMPILER=clang++ \
-  -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-RelWithDebInfo}" \
+  -DLLVM_EXTERNAL_PROJECTS="$LLVM_EXTERNAL_PROJECTS" \
+  -DLLVM_EXTERNAL_MLIRSWIFTSUPPORT_SOURCE_DIR="${TOOLS_ROOT}/MLIRSwiftSupport" \
   "${LLVM_ADDITIONAL_CMAKE_ARGS_ARRAY[@]}")
 (set -x; cmake \
   --build "$LLVM_BUILD_ROOT" \


### PR DESCRIPTION
MLIRSwiftSupport provides a staging ground for binding LLVM and MLIR APIs, so we can validate their usefulness before attempting to commit them upstream.